### PR TITLE
fix delete command and run expiration sweep always

### DIFF
--- a/assign-users.js
+++ b/assign-users.js
@@ -37,6 +37,7 @@ async function assignExpiringLearners() {
     return getLearnerQueue(priorityQueue.length, PRUNEDATE).then((learnerSnap)=>{
       if (learnerSnap === undefined || learnerSnap.empty) {
         console.log('no new learners to assign');
+        sweepExpiredLearners();
         return;
       }
       console.log('prioritizing snap of size ', learnerSnap.size);
@@ -223,7 +224,7 @@ function sweepExpiredLearners() {
           let id = doc.id;
           data['expiredOn'] = admin.firestore.Timestamp.now();
           batches[batchCount].set(expiredRef.doc(id), data);
-          batches[batchCount].delete(poolRef.doc('id'));
+          batches[batchCount].delete(poolRef.doc(id));
           batchSize +=2;
         });
         return batches;


### PR DESCRIPTION
- fix issue where expired learners were not being removed from the user_pool
- fix issue where sweep of expired learners was not run if there were no users to assign