### PR TITLE
pre-aggregate users before ingestion

### DIFF
--- a/service_scripts/user-update.js
+++ b/service_scripts/user-update.js
@@ -1,9 +1,10 @@
 const {BigQuery} = require('@google-cloud/bigquery');
-const fireStoreAdmin = require('firebase-admin');
+const admin = require('firebase-admin');
 const {get, isNil} = require('lodash');
 const {Client, Status} = require('@googlemaps/google-maps-services-js');
 const PRUNEDATE = 7;
 const DAYINMS = 86400000;
+const HOURINMS = 3600000;
 const CONTINENTS = [
   'Africa',
   'Americas',
@@ -13,13 +14,14 @@ const CONTINENTS = [
   'Oceania',
 ];
 
-if (fireStoreAdmin.apps.length === 0) {
-  fireStoreAdmin.initializeApp();
+if (admin.apps.length === 0) {
+  admin.initializeApp();
 }
 const {BatchManager} = require('../helpers/batchManager');
-const firestore = fireStoreAdmin.firestore();
+const firestore = admin.firestore();
 const gmaps = new Client({});
 const countriesAddedOrExist = [];
+const Timestamp = admin.firestore.Firestore.Timestamp;
 
 /**
 * main function
@@ -52,6 +54,7 @@ async function main() {
       console.log(`successful Query - retrieved ${rows.length} new users`);
       let batchManager = new BatchManager();
       let usedIDs = [];
+      let aggregates = {};
       let counter = 0;
       let doubleCounter = 0;
       for (const row of rows) {
@@ -60,17 +63,20 @@ async function main() {
         if (!usedIDs.includes(row.user)) {
           counter++;
           usedIDs.push(row.user);
-          addUserToPool(createUser(row), batchManager);
+          const user = createUser(row);
+          addUserToPool(user, batchManager);
+          aggregates = countUser(user, aggregates);
           await insertLocation(row);
         } else {
           console.log(`excluding ${row.user}, already counted`);
           doubleCounter++;
         }
       }
-
       console.log('created ', counter, ' new users');
-      await batchManager.commit();
       console.log('doubleCounter: ' + doubleCounter);
+      await batchManager.commit();
+      await updateCounts(aggregates);
+      console.log('finished updating counts');
     } catch (err) {
       console.error('ERROR', err);
     }
@@ -79,33 +85,208 @@ async function main() {
 }
 
 /**
-* @return {Promise} a promise that waits for 1 second before continuing
+* update all aggregate counts relevant to this user
+* @param{Object} user the user being counted
+* @param{Object} aggregates the aggregate counts object
+* @return{Object} the updated aggregates object
 */
-function waitForSecond() {
-  return new Promise((resolve) =>{
-    setTimeout(()=>{
-      resolve('resolved');
-    }, 1010);
+function countUser(user, aggregates) {
+  if (!aggregates.master) {
+    aggregates['master'] = {
+      newLearners: 1,
+      dntLearners: 0,
+      path: firestore.collection('aggregate_data').doc('data'),
+    };
+    if (user.country === 'no-country') {
+      aggregates.master['dntLearners'] = 1;
+    }
+    aggregates['campaigns'] = [{
+      campaign: user.sourceCampaign,
+      newLearners: 1,
+      path: firestore.doc(`campaigns/${user.sourceCampaign}`),
+    }];
+    aggregates['countries'] = [{
+      country: user.country,
+      newLearners: 1,
+      regions: [{
+        region: user.region,
+        newLearners: 1,
+      }],
+      path: firestore.doc(`loc_ref/${user.country}`),
+    }];
+    return aggregates; // early return for first entries
+  }
+
+  aggregates.master.newLearners++;
+  if (user.country === 'no-country') {
+    aggregates.master.dntLearners++;
+  }
+
+  const campaignIndex = aggregates.campaigns.findIndex(
+      (x)=> x.campaign === user.sourceCampaign
+  );
+  if (campaignIndex < 0) {
+    aggregates.campaigns.push({
+      campaign: user.sourceCampaign,
+      path: firestore.doc(`campaigns/${user.campaign}`),
+      newLearners: 1,
+    });
+  } else {
+    aggregates.campaigns[campaignIndex].newLearners++;
+  }
+
+  const countryIndex = aggregates.countries.findIndex(
+      (x)=> x.country === user.country
+  );
+  let country = aggregates.countries[countryIndex];
+  if (countryIndex < 0 ) {
+    aggregates.countries.push({
+      country: user.country,
+      newLearners: 1,
+      path: firestore.doc(`loc_ref/${user.country}`),
+      regions: [{
+        region: user.region,
+        newLearners: 1,
+      }],
+    });
+  } else if (country.regions.findIndex((x)=> x.region === user.region) < 0) {
+    country.newLearners++;
+    country.regions.push({
+      region: user.region,
+      newLearners: 1,
+    });
+  } else {
+    country.newLearners++;
+    const region = country.regions.findIndex((x) => x.region === user.region);
+    country.regions[region].newLearners++;
+  }
+  return aggregates;
+}
+
+/**
+* take the count object and update individual counts
+* a document is not updated if it was updated in the last 12 hours, unless
+* it was created within the last hour
+* @param{Object} counts the object containing the aggregated learner counts
+*/
+async function updateCounts(counts) {
+  // don't update the count if doc has been updated in the last 12 hours
+  const updateBuffer = Timestamp.fromDate(new Date(Date.now() - DAYINMS/2));
+  await firestore.runTransaction((transaction) => {
+    return transaction.get(counts.master.path).then(async (doc) => {
+      if (doc.updateTime >= updateBuffer) {
+        return new Promise((resolve) => {
+          resolve('did not update');
+        });
+      }
+      console.log(`adding ${counts.master.newLearners} learners to master count`);
+      console.log(`adding ${counts.master.dntLearners} learners to dnt count`);
+      let data = doc.data();
+      data.allLearnersCount += counts.master.newLearners;
+      data.allLearnersWithDoNotTrack += counts.master.dntLearners;
+      return await transaction.set(counts.master.path, data, {merge: true});
+    });
+  }).then(() => {
+    console.log('successfully updated master count');
+  }).catch((err) => {
+    console.error(`unable to update master counts. Encountered error: ${err}`);
+  });
+  await updateCampaigns(counts.campaigns, updateBuffer).then(() => {
+    console.log('successfully updated campaign counts');
+  }).catch((err) => {
+    console.error(`unable to update campaigns. Encountered error: ${err}`);
+  });
+  await updateCountries(counts.countries, updateBuffer).then(() => {
+    console.log('successfully updated country counts');
+  }).catch((err) => {
+    console.error(`unable to update countries. Encountered error: ${err}`);
   });
 }
 
 /**
-* Loop through an array of firestore batches and commit each one
-* working at a rate of 1 batch/second
-* @param{Object[]} arr the array of batches to commit to
+* Loop through the campaigns array and update each campaign with the new count
+* @param{Array} campaigns an array of the new learner counts for any campaigns
+* @param{Firestore.Timestamp} updateBuffer a buffer to prevent multiple updates
+* @return{Promise} a promise that resolves if all documents are updated.
 */
-async function writeToDb(arr) {
-  console.log('beginning write');
-  for(const [index, a] of arr.entries()) {
-    console.log(`writing batch: ${index}`);
-    try {
-      await a.commit();
-    } catch(err) {
+ async function updateCampaigns(campaigns, updateBuffer) {
+  let paths = [];
+  campaigns.forEach((doc) => {
+    paths.push(doc.path);
+  });
+  return firestore.runTransaction((transaction) => {
+    return transaction.getAll(...paths).then((docs) => {
+      docs.forEach((doc) => {
+        if (doc.exists &&
+          (doc.createTime.getMillis() >= (Date.now() - HOURINMS) ||
+          doc.updateTime < updateBuffer)) {
+          let data = doc.data();
+          const index = campaigns.findIndex(
+              (x) => x.campaign === data.campaignID
+          );
+          if (index >= 0) {
+            const update = campaigns[index];
+            console.log(`adding ${update.newLearners} learners to ${data.campaignID}`);
+            transaction.update(doc.ref, {
+              learnerCount: data.learnerCount + update.newLearners,
+            }, {merge: true});
+          }
+        }
+      });
+    }).catch((err) => {
+      console.error('error updating campaigns');
       console.error(err);
-    }
-    console.log(`wrote batch: ${index}`);
-    await waitForSecond();
-  }
+    });
+  });
+}
+
+/**
+* Loop through the countries array and update each document with the new counts
+* @param{Object} countries the array of country documents and their counts
+* @param{Firestore.Timestamp} updateBuffer buffer to prevent multiple updates
+*/
+async function updateCountries(countries, updateBuffer) {
+  let paths = [];
+  countries.forEach((doc) => {
+    paths.push(doc.path);
+  });
+
+  return firestore.runTransaction((transaction) => {
+    return transaction.getAll(...paths).then((docs) => {
+      docs.forEach((doc) => {
+        if (doc.exists &&
+          (doc.createTime.getMillis() >= (Date.now() - HOURINMS) ||
+          doc.updateTime < updateBuffer)) {
+          let data = doc.data();
+          const index = countries.findIndex((x) => x.country === data.country);
+          if (index >= 0) {
+            const update = countries[index];
+            console.log(`adding ${update.newLearners} learners to ${data.country}`);
+            update.regions.forEach((region) => {
+              let rIndex = data.regions.findIndex(
+                  (x) => x.region === region.region
+              );
+              if (rIndex < 0) {
+                data.regions.push({
+                  region: region.region,
+                  learnerCount: region.newLearners,
+                });
+              } else {
+                let docReg = data.regions[rIndex];
+                docReg.learnerCount += region.newLearners;
+              }
+              console.log(`\tadding ${region.newLearners} to ${region.region}`);
+            });
+            data.learnerCount += update.newLearners;
+          }
+          transaction.set(doc.ref, data, {merge: true});
+        }
+      });
+    }).catch((err) => {
+      console.error('error updating countries');
+      console.error(err);
+    });
+  });
 }
 
 /**
@@ -118,7 +299,7 @@ async function insertLocation(row) {
   let doc, locationRef;
   try {
     locationRef = firestore.collection('loc_ref').doc(row.country);
-    doc = locationRef.get();
+    doc = await locationRef.get();
   } catch(err) {
     console.error(`Error when trying to retrieve the location for country: ${row.country}.  Skipping user: ${row.user_pseudo_id}`);
     return;
@@ -203,16 +384,19 @@ function createUser(row) {
     row.country = 'no-country';
   }
   if (isNil(row.continent) || row.continent === '') {
-    row.continent = 'not-set';
+    row.continent = 'no-continent';
     if (isNil(row.country) || row.country == '') {
-      row.country = 'not-set';
+      row.country = 'no-country';
     }
+  }
+  if (isNil(row.name) || row.name === '') {
+    row.name = 'no-campaign';
   }
 
   const user = {
     userID: row.user,
     dateCreated: makeTimestamp(row.event_date),
-    dateIngested: fireStoreAdmin.firestore.Timestamp.now(),
+    dateIngested: admin.firestore.Timestamp.now(),
     sourceCampaign: row.name,
     region: row.region,
     country: row.country,
@@ -235,7 +419,7 @@ function makeTimestamp(date) {
   const day = date.slice(6);
   const dateString = year.toString()+'-'+month.toString()+'-'+day.toString();
   const parsedDate = new Date(dateString);
-  return fireStoreAdmin.firestore.Timestamp.fromDate(parsedDate);
+  return admin.firestore.Timestamp.fromDate(parsedDate);
 }
 
 /**


### PR DESCRIPTION
compile aggregate counts of new learners as they are prepped for ingestion to ensure that firestore internal aggregations remain accurate over time.
Added a buffer to prevent against counting the same batch of users multiple times: if an aggregate document has been edited in the last 12 hours, do not update it again. The exception is for documents created within the last hour (to allow for users who are the first in their country to be ingested to be counted)